### PR TITLE
Added Support for In-active Sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cofinder",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cofinder",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"dependencies": {
 				"@reduxjs/toolkit": "^1.9.2",
 				"axios": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cofinder",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"private": true,
 	"main": "src/index.tsx",
 	"dependencies": {

--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -52,7 +52,7 @@
 }
 
 .dark {
-	@apply bg-slate-1000;
+	@apply bg-slate-1000 text-gray-100;
 }
 
 a,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const APP_NAME = "CoFinder";
-export const VERSION_CODE: string = "0.1.3";
+export const VERSION_CODE: string = "0.1.4";
 
 // School
 export const SCHOOL_FULL_NAME: string = "University of the Fraser Valley";

--- a/src/features/Calendar/CalendarContent.tsx
+++ b/src/features/Calendar/CalendarContent.tsx
@@ -37,6 +37,9 @@ export default function Content() {
 			// Iterate over all the sections user is enrolled in
 			for (let i = 0; i < detailedSchedule.sections.length; i++) {
 				let section = detailedSchedule.sections[i];
+				if (!section.is_active) {
+					continue;
+				}
 				// Iterate all schedule enteries that section has
 				for (let j = 0; j < section.schedule.length; j++) {
 					let section_schedule: ScheduleType =

--- a/src/features/CourseBrowser/ListRow.tsx
+++ b/src/features/CourseBrowser/ListRow.tsx
@@ -30,6 +30,9 @@ export function ListRow(props: Props) {
 	let expandRef: React.RefObject<any> = React.useRef<HTMLDivElement>(null);
 
 	React.useEffect(() => {
+		if (!props.section.is_active) {
+			return;
+		}
 		if (expand && seatInfo === null) {
 			setIsLoadingSeats(true);
 			axios
@@ -58,7 +61,7 @@ export function ListRow(props: Props) {
 	}, [expand, props.section.crn, seatInfo, props.term.date]);
 
 	function addToSelected() {
-		if (!props.doesCollide) {
+		if (!props.doesCollide && props.section.is_active) {
 			props.addToSchedule(props.section);
 		}
 	}
@@ -93,10 +96,14 @@ export function ListRow(props: Props) {
 		S: "Saturday",
 	};
 
+	const inactiveSectionClass = props.section.is_active
+		? ""
+		: " dark:text-white line-through opacity-50 ";
 	const rowItemClass =
 		(props.doesCollide && !props.isSelected ? "opacity-50" : "") +
 		" items-center text-smb leading-5 pr-4 lg:py-2" +
-		" text-gray-700 dark:text-white dark:text-opacity-80";
+		" text-gray-700 dark:text-white dark:text-opacity-80" +
+		inactiveSectionClass;
 
 	return (
 		<div>
@@ -106,7 +113,7 @@ export function ListRow(props: Props) {
 						? "bg-accent-200 dark:bg-slate-1000"
 						: props.isSelected
 						? "bg-accent-200 dark:bg-accent-700"
-						: props.doesCollide
+						: props.doesCollide || !props.section.is_active
 						? "bg-gray-100 dark:bg-slate-900"
 						: ""
 				}
@@ -125,6 +132,9 @@ export function ListRow(props: Props) {
 					<div className="col-span-3 flex pr-4">
 						<button
 							onClick={() => {
+								if (!props.isSelected && !props.section.is_active) {
+									return;
+								}
 								if (!props.doesCollide || props.isSelected)
 									toggleSelected();
 							}}
@@ -136,6 +146,7 @@ export function ListRow(props: Props) {
 									: "hover:bg-accent-300 text-gray-400 hover:text-gray-700 dark:hover:text-white dark:hover:bg-accent-700") +
 								" grid place-items-center px-4 tw-tooltip-parent"
 							}
+							disabled={!props.isSelected && !props.section.is_active}
 						>
 							<span
 								className={
@@ -174,7 +185,8 @@ export function ListRow(props: Props) {
 								onClick={() => toggleExpand()}
 								className={
 									(expand ? "bg-accent-300 dark:bg-slate-600" : "") +
-									" w-8 h-8 rounded-full hover:bg-accent-300 dark:hover:bg-slate-500 my-2 ml-2"
+									" w-8 h-8 rounded-full hover:bg-accent-300 dark:hover:bg-slate-500 my-2 ml-2" +
+									inactiveSectionClass
 								}
 							>
 								<span
@@ -197,7 +209,17 @@ export function ListRow(props: Props) {
 								" grid place-items-center ml-2 leading-5 lg:py-2 dark:text-white order-2 lg:order-3 flex-1 lg:flex-none"
 							}
 						>
-							<div className="w-full font-medium lg:font-normal">
+							{!props.section.is_active && (
+								<div className="opacity-70 place-self-start">
+									Cancelled
+								</div>
+							)}
+							<div
+								className={
+									"w-full font-medium lg:font-normal" +
+									inactiveSectionClass
+								}
+							>
 								{props.section.subject_id} {props.section.course.code}{" "}
 								{props.section.is_lab ? (
 									<span className="bg-accent-200 dark:bg-accent-600 ml-0.5 align-top text-accent-700 dark:text-white uppercase px-1 text-[0.8rem] font-medium rounded">
@@ -250,7 +272,7 @@ export function ListRow(props: Props) {
 					<div
 						className={
 							rowItemClass +
-							" lg:flex col-span-2 pl-[3.65rem] py-1 lg:py-0 lg:pl-0 pb-3 lg:pb-0"
+							" lg:flex col-span-2 pl-[3.65rem] py-1 lg:pt-0 lg:pl-0 pb-3 lg:pb-0"
 						}
 					>
 						{props.section.instructor}

--- a/src/features/CourseBrowser/ListRowExpandInfo.tsx
+++ b/src/features/CourseBrowser/ListRowExpandInfo.tsx
@@ -1,3 +1,4 @@
+import { INACTIVE_SECTION_MSG } from "@/strings";
 import {
 	ScheduleType,
 	SeatsInfoType,
@@ -17,6 +18,11 @@ export interface IListRowExpandInfoProps {
 export default function ListRowExpandInfo(props: IListRowExpandInfoProps) {
 	return (
 		<div className="bg-gray-300 dark:bg-slate-1000 bg-opacity-30 px-4 pl-14 py-4 pb-5 grid grid-flow-row gap-3">
+			{!props.section.is_active && (
+				<div className="font-bold text-red-700 dark:text-red-400">
+					{INACTIVE_SECTION_MSG}
+				</div>
+			)}
 			<div>
 				<span className="bg-gray-600 text-gray-200 rounded-lg px-1.5 py-0.5 mr-3 text-sm">
 					CRN

--- a/src/features/CourseBrowser/SelectionBar.tsx
+++ b/src/features/CourseBrowser/SelectionBar.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from "@/redux/hooks";
 import { refactorTime } from "@/utils/RefactorDateTime";
 import { ReduxDetailedScheduleType } from "@/types/stateTypes";
 import { useFetchSpecificSections } from "@/services/core/fetch_specific_sections";
+import { INACTIVE_SECTION_MSG } from "@/strings";
 
 export default function SelectionBar() {
 	const mySchedule = useAppSelector((state: RootState) => state.mySchedule);
@@ -151,7 +152,14 @@ export default function SelectionBar() {
 											}}
 										></div>
 										<div className="rounded py-2.5 px-3 bg-white dark:bg-slate-800 bg-opacity-70 flex-1">
-											<h6 className="font-bold leading-5 dark:text-white">
+											<h6
+												className={
+													(!section.is_active
+														? "line-through "
+														: "") +
+													"font-bold leading-5 dark:text-white"
+												}
+											>
 												{section.subject_id} {section.course.code}
 												{" - "}
 												{section.name}
@@ -167,103 +175,115 @@ export default function SelectionBar() {
 												{section.instructor} • {section.crn} •{" "}
 												{section.medium}
 											</div>
-											<div className="pt-1">
-												{section.schedule
-													.slice()
-													.reverse()
-													.map((schedule, index) => {
-														return (
-															<span
-																key={index}
-																className="text-[0.925rem] text-gray-600 dark:text-slate-300"
-															>
-																<div
-																	className={
-																		section.schedule
-																			.slice()
-																			.reverse()[
-																			index - 1
-																		] &&
-																		section.schedule
-																			.slice()
-																			.reverse()[
-																			index - 1
-																		].date_start ===
-																			schedule.date_start &&
-																		section.schedule
-																			.slice()
-																			.reverse()[
-																			index - 1
-																		].date_end ===
-																			schedule.date_end
-																			? "hidden"
-																			: "block mb-3 mt-4"
-																	}
+											{section.is_active ? (
+												<div className="pt-1">
+													{section.schedule
+														.slice()
+														.reverse()
+														.map((schedule, index) => {
+															return (
+																<span
+																	key={index}
+																	className="text-[0.925rem] text-gray-600 dark:text-slate-300"
 																>
-																	<span className="text-accent-900 dark:text-white text-[0.9rem] font-medium bg-accent-200 dark:bg-accent-700 dark:bg-opacity-70 rounded px-2 py-0.5">
-																		{refactorDate(
-																			schedule.date_start
-																		)}
-																		{" — "}
-																		{refactorDate(
-																			schedule.date_end
-																		)}
+																	<div
+																		className={
+																			section.schedule
+																				.slice()
+																				.reverse()[
+																				index - 1
+																			] &&
+																			section.schedule
+																				.slice()
+																				.reverse()[
+																				index - 1
+																			]
+																				.date_start ===
+																				schedule.date_start &&
+																			section.schedule
+																				.slice()
+																				.reverse()[
+																				index - 1
+																			].date_end ===
+																				schedule.date_end
+																				? "hidden"
+																				: "block mb-3 mt-4"
+																		}
+																	>
+																		<span className="text-accent-900 dark:text-white text-[0.9rem] font-medium bg-accent-200 dark:bg-accent-700 dark:bg-opacity-70 rounded px-2 py-0.5">
+																			{refactorDate(
+																				schedule.date_start
+																			)}
+																			{" — "}
+																			{refactorDate(
+																				schedule.date_end
+																			)}
+																		</span>
+																	</div>
+																	{section.schedule
+																		.slice()
+																		.reverse()[
+																		index - 1
+																	] &&
+																	section.schedule
+																		.slice()
+																		.reverse()[
+																		index - 1
+																	].time_start ===
+																		schedule.time_start &&
+																	section.schedule
+																		.slice()
+																		.reverse()[
+																		index - 1
+																	].time_end ===
+																		schedule.time_end ? (
+																		<> </>
+																	) : (
+																		<span className="dark:text-white font-medium text-black text-[0.94rem]">
+																			{index !==
+																			0 ? (
+																				<div className="my-1 border dark:border-slate-700"></div>
+																			) : (
+																				<></>
+																			)}
+																			{refactorTime(
+																				schedule.time_start
+																			)}
+																			{" to "}
+																			{refactorTime(
+																				schedule.time_end
+																			)}
+																			{": "}
+																		</span>
+																	)}
+																	<span className="dark:text-white text-accent-700 font-medium">
+																		{schedule.weekday
+																			? Weekdays[
+																					schedule.weekday as keyof typeof Weekdays
+																			  ]
+																			: "[TBA]"}
 																	</span>
-																</div>
-																{section.schedule
-																	.slice()
-																	.reverse()[
-																	index - 1
-																] &&
-																section.schedule
-																	.slice()
-																	.reverse()[index - 1]
-																	.time_start ===
-																	schedule.time_start &&
-																section.schedule
-																	.slice()
-																	.reverse()[index - 1]
-																	.time_end ===
-																	schedule.time_end ? (
-																	<> </>
-																) : (
-																	<span className="dark:text-white font-medium text-black text-[0.94rem]">
-																		{index !== 0 ? (
-																			<div className="my-1 border dark:border-slate-700"></div>
-																		) : (
-																			<></>
-																		)}
-																		{refactorTime(
-																			schedule.time_start
-																		)}
-																		{" to "}
-																		{refactorTime(
-																			schedule.time_end
-																		)}
-																		{": "}
+																	{" at "}
+																	<span className="dark:text-white text-black font-medium">
+																		{schedule.location
+																			.campus +
+																			schedule
+																				.location
+																				.building +
+																			" " +
+																			schedule
+																				.location
+																				.room}
 																	</span>
-																)}
-																<span className="dark:text-white text-accent-700 font-medium">
-																	{schedule.weekday
-																		? Weekdays[
-																				schedule.weekday as keyof typeof Weekdays
-																		  ]
-																		: "[TBA]"}
 																</span>
-																{" at "}
-																<span className="dark:text-white text-black font-medium">
-																	{schedule.location
-																		.campus +
-																		schedule.location
-																			.building +
-																		" " +
-																		schedule.location
-																			.room}
-																</span>
-															</span>
-														);
-													})}
-											</div>
+															);
+														})}
+												</div>
+											) : (
+												<div className="font-bold text-red-700 dark:text-red-400 my-2 leading-5">
+													{INACTIVE_SECTION_MSG}
+												</div>
+											)}
 										</div>
 										<div className="flex-none">
 											<button

--- a/src/features/Home/MyCourses.tsx
+++ b/src/features/Home/MyCourses.tsx
@@ -99,56 +99,64 @@ function SectionItem({ section }: { section: SectionsBrowserType }) {
 	let color: string = getColor(section.subject_id);
 	return (
 		<div className="bg-white dark:bg-slate-800 border-[0.025rem] border-gray-400 dark:border-slate-600 border-opacity-30 shadow-sm">
-			<div
-				className={
-					"tw-gradient-br-" +
-					color.replace("#", "") +
-					" dark:tw-gradient-br-" +
-					color.replace("#", "") +
-					" h-24 w-24 px-4 pt-4"
-				}
-				// style={{
-				// 	background: `linear-gradient(to bottom right, ${color}, #fff 70%)`,
-				// }}
-			></div>
+			{section.is_active ? (
+				<div
+					className={
+						"tw-gradient-br-" +
+						color.replace("#", "") +
+						" dark:tw-gradient-br-" +
+						color.replace("#", "") +
+						" h-24 w-24 px-4 pt-4"
+					}
+				></div>
+			) : (
+				<div className="h-24 w-24"></div>
+			)}
 			<div className="z-10 px-4 pb-3 -mt-20">
-				<div className="font-bold text-[1.125rem] dark:text-slate-100 leading-[1.125rem]">
-					{section.is_lab ? (
-						<span
-							style={{ color: color }}
-							className="mr-1.5 bg-black bg-opacity-80 align-top px-1 rounded text-[0.8rem] font-medium"
-						>
-							LAB
-						</span>
-					) : (
-						<></>
-					)}
-					{section.subject_id} {section.course.code}
-					{" - "}
-					{section.name}
-				</div>
-				<div className="mt-1.5">
-					<p className="mt-1 text-gray-700 dark:text-slate-300 leading-[1.125rem]">
-						<span className="block uppercase text-[0.9rem] font-bold">
-							{section.course.name}
-						</span>
-						<span className="mt-2 block leading-[1.125rem] text-[0.925rem] text-gray-800 dark:text-slate-300">
-							{section.instructor}
-						</span>
-					</p>
-					<p className="mt-3">
-						<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
-							{section.crn}
-						</span>
-						<span className="pl-1"></span>{" "}
-						<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
-							Credits: {section.course.credits}
-						</span>
-						<span className="pl-1"></span>{" "}
-						<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
-							{section.subject}
-						</span>
-					</p>
+				{!section.is_active && (
+					<div className="font-bold text-sm mb-4 uppercase py-0.5 mr-2 text-red-700 dark:text-red-200 bg-red-100 dark:bg-red-600/20 rounded inline-block px-2">
+						Cancelled
+					</div>
+				)}
+				<div className={!section.is_active ? "line-through" : ""}>
+					<div className="font-bold text-[1.125rem] dark:text-slate-100 leading-[1.125rem]">
+						{section.is_lab ? (
+							<span
+								style={{ color: color }}
+								className="mr-1.5 bg-black bg-opacity-80 align-top px-1 rounded text-[0.8rem] font-medium"
+							>
+								LAB
+							</span>
+						) : (
+							<></>
+						)}
+						{section.subject_id} {section.course.code}
+						{" - "}
+						{section.name}
+					</div>
+					<div className="mt-1.5">
+						<p className="mt-1 text-gray-700 dark:text-slate-300 leading-[1.125rem]">
+							<span className="block uppercase text-[0.9rem] font-bold">
+								{section.course.name}
+							</span>
+							<span className="mt-2 block leading-[1.125rem] text-[0.925rem] text-gray-800 dark:text-slate-300">
+								{section.instructor}
+							</span>
+						</p>
+						<p className="mt-3">
+							<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
+								{section.crn}
+							</span>
+							<span className="pl-1"></span>{" "}
+							<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
+								Credits: {section.course.credits}
+							</span>
+							<span className="pl-1"></span>{" "}
+							<span className="bg-gray-300 dark:bg-slate-700 dark:text-slate-100 bg-opacity-70 text-[0.9rem] text-gray-900 px-1 rounded">
+								{section.subject}
+							</span>
+						</p>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/features/Home/UpcomingClasses.tsx
+++ b/src/features/Home/UpcomingClasses.tsx
@@ -42,6 +42,9 @@ export default function UpcomingClasses() {
 		let result: UpcomingSection[] = [];
 		if (schedule && schedule.sections?.length > 0) {
 			for (const section of schedule.sections) {
+				if (!section.is_active) {
+					continue;
+				}
 				for (const slot of section.schedule) {
 					let start_date = getDayAfterDate(
 						convertToJsDate(slot.date_start.toString()),

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,0 +1,1 @@
+export const INACTIVE_SECTION_MSG = "This section is not active or has been cancelled.";


### PR DESCRIPTION
# Summary

Prior to this release, the sections that were set inactive in backend were still visible as available. This release fixes the issue.

Version bump to 0.1.4

## In CourseBrowser

![image](https://github.com/gauravjot/cofinder-frontend/assets/11373684/f894af21-c539-4c6f-98fe-cfde527f1312)

## On main page

![Selection_025](https://github.com/gauravjot/cofinder-frontend/assets/11373684/43df5da9-3cc9-4165-9f95-a12cc5b4f6ca)

## What happens if a user selected section becomes inactive?

User will still be able to remove the section however will not be able to select such sections. Inactive sections will not be removed automatically and will come up as shown in above screenshots.